### PR TITLE
Fix data serialisation and some other errors, bump PAL

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@ archives_base_name = essential_commands
 # Dependencies
 permissions_api_version=0.3.3
 placeholder_api_version=2.5.0+1.21.2
-pal_version=1.10.0
+pal_version=1.13.0
 vanish_version=1.5.3+1.20.4
 
 jetbrains_annotations_version = 22.0.0

--- a/src/main/java/com/fibermc/essentialcommands/WorldDataManager.java
+++ b/src/main/java/com/fibermc/essentialcommands/WorldDataManager.java
@@ -22,17 +22,14 @@ import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtElement;
 import net.minecraft.nbt.NbtIo;
 import net.minecraft.nbt.NbtSizeTracker;
-import net.minecraft.registry.DynamicRegistryManager;
-import net.minecraft.registry.RegistryWrapper;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.WorldSavePath;
-import net.minecraft.world.PersistentState;
 
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
 
-public class WorldDataManager extends PersistentState {
+public class WorldDataManager {
     private final WarpStorage warps;
     private MinecraftLocation spawnLocation;
     private Path saveDir;
@@ -69,8 +66,7 @@ public class WorldDataManager extends PersistentState {
                 // if files was not JUST created, read data from it.
                 this.fromNbt(NbtIo.readCompressed(worldDataFile.toPath(), NbtSizeTracker.ofUnlimitedBytes()).getCompoundOrEmpty("data"));
             } else {
-                this.markDirty();
-                this.save(server.getRegistryManager());
+                this.save();
             }
         } catch (IOException e) {
             EssentialCommands.log(Level.ERROR, String.format("An unexpected error occoured while loading the Essential Commands World Data file (Path: '%s')", worldDataFile.getPath()));
@@ -83,12 +79,8 @@ public class WorldDataManager extends PersistentState {
     }
 
     public void fromNbt(NbtCompound tag) {
-        MinecraftLocation tempSpawnLocation = MinecraftLocation.fromNbt(tag.getCompoundOrEmpty(SPAWN_KEY));
-        if (tempSpawnLocation.dim().getValue().getPath().isEmpty()) {
-            this.spawnLocation = null;
-        } else {
-            this.spawnLocation = tempSpawnLocation;
-        }
+        this.spawnLocation = MinecraftLocation.fromNbt(tag.getCompoundOrEmpty(SPAWN_KEY));
+
         NbtCompound warpsNbt = tag.getCompoundOrEmpty(WARPS_KEY);
         warps.loadNbt(warpsNbt);
         warpsLoadEvent.invoker().accept(warps);
@@ -102,9 +94,10 @@ public class WorldDataManager extends PersistentState {
             }
         });
 
-    public void save(RegistryWrapper.WrapperLookup wrapperLookup) {
+    public void save() {
         EssentialCommands.log(Level.INFO, "Saving world_data.dat (Spawn/Warps)...");
-        NbtCompound data = this.writeNbt(new NbtCompound(), wrapperLookup);
+        NbtCompound data = new NbtCompound();
+        data.put("data", this.writeNbt());
         try {
             NbtIo.writeCompressed(data, this.worldDataFile.toPath());
         } catch (IOException e) {
@@ -113,8 +106,8 @@ public class WorldDataManager extends PersistentState {
         EssentialCommands.log(Level.INFO, "world_data.dat saved.");
     }
 
-    @Override
-    public NbtCompound writeNbt(NbtCompound tag, RegistryWrapper.WrapperLookup wrapperLookup) {
+    private NbtCompound writeNbt() {
+        NbtCompound tag = new NbtCompound();
         // Spawn to NBT
         NbtElement spawnNbt = spawnLocation != null
             ? spawnLocation.asNbt()
@@ -137,14 +130,12 @@ public class WorldDataManager extends PersistentState {
             requiresPermission ? warpName : null,
             warpName
         ));
-        this.markDirty();
-        this.save(DynamicRegistryManager.EMPTY);
+        this.save();
     }
 
     public boolean delWarp(String warpName) {
         MinecraftLocation prevValue = warps.remove(warpName);
-        this.markDirty();
-        this.save(DynamicRegistryManager.EMPTY);
+        this.save();
         return prevValue != null;
     }
 
@@ -169,8 +160,7 @@ public class WorldDataManager extends PersistentState {
 
     public void setSpawn(MinecraftLocation location) {
         spawnLocation = location;
-        this.markDirty();
-        this.save(DynamicRegistryManager.EMPTY);
+        this.save();
     }
 
     public Optional<MinecraftLocation> getSpawn() {

--- a/src/main/java/com/fibermc/essentialcommands/commands/BedCommand.java
+++ b/src/main/java/com/fibermc/essentialcommands/commands/BedCommand.java
@@ -51,13 +51,14 @@ public class BedCommand implements Command<ServerCommandSource> {
      * block)
      */
     private static Optional<MinecraftLocation> getSafeSpawnPos(ServerPlayerEntity player) {
-        var spawnPos = player.getSpawnPointPosition();
-        if (spawnPos == null) {
+        var respawn = player.getRespawn();
+        if (respawn == null) {
             return Optional.empty();
         }
 
-        var spawnDim = player.getSpawnPointDimension();
-        var spawnAngle = player.getSpawnAngle();
+        var spawnPos = respawn.pos();
+        var spawnDim = respawn.dimension();
+        var spawnAngle = respawn.angle();
 
         var world = Objects.requireNonNull(player.getServer()).getWorld(spawnDim);
 

--- a/src/main/java/com/fibermc/essentialcommands/commands/ProfileCommand.java
+++ b/src/main/java/com/fibermc/essentialcommands/commands/ProfileCommand.java
@@ -32,8 +32,7 @@ public final class ProfileCommand {
                     var player = context.getSource().getPlayerOrThrow();
                     var profile = ((ServerPlayerEntityAccess) player).ec$getProfile();
                     option.profileSetter().setValue(context, "value", profile);
-                    profile.markDirty();
-                    profile.save(context.getSource().getServer().getRegistryManager());
+                    profile.save();
                     return 0;
                 }))
             );

--- a/src/main/java/com/fibermc/essentialcommands/mixin/PlayerEntityMixin.java
+++ b/src/main/java/com/fibermc/essentialcommands/mixin/PlayerEntityMixin.java
@@ -3,6 +3,7 @@ package com.fibermc.essentialcommands.mixin;
 import com.fibermc.essentialcommands.access.ServerPlayerEntityAccess;
 import com.fibermc.essentialcommands.playerdata.PlayerData;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
@@ -19,6 +20,10 @@ import static com.fibermc.essentialcommands.EssentialCommands.CONFIG;
 
 @Mixin(PlayerEntity.class)
 public abstract class PlayerEntityMixin {
+
+    @Shadow
+    public abstract boolean isSpectator();
+
     @Inject(method = "getDisplayName", at = @At("RETURN"))
     public void onGetDisplayName(CallbackInfoReturnable<Text> cir) {
 

--- a/src/main/java/com/fibermc/essentialcommands/mixin/ServerPlayerEntityMixin.java
+++ b/src/main/java/com/fibermc/essentialcommands/mixin/ServerPlayerEntityMixin.java
@@ -12,7 +12,6 @@ import com.fibermc.essentialcommands.teleportation.QueuedTeleport;
 import com.fibermc.essentialcommands.text.ECText;
 import com.fibermc.essentialcommands.types.MinecraftLocation;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -33,9 +32,6 @@ import static com.fibermc.essentialcommands.EssentialCommands.CONFIG;
 
 @Mixin(ServerPlayerEntity.class)
 public abstract class ServerPlayerEntityMixin extends PlayerEntityMixin implements ServerPlayerEntityAccess {
-
-    @Shadow
-    public abstract boolean isSpectator();
 
     @Unique
     public QueuedTeleport ecQueuedTeleport;

--- a/src/main/java/com/fibermc/essentialcommands/playerdata/PlayerData.java
+++ b/src/main/java/com/fibermc/essentialcommands/playerdata/PlayerData.java
@@ -44,7 +44,6 @@ import net.minecraft.text.HoverEvent;
 import net.minecraft.text.MutableText;
 import net.minecraft.text.Text;
 import net.minecraft.util.math.Vec3d;
-import net.minecraft.world.PersistentState;
 
 import net.fabricmc.fabric.api.event.Event;
 import net.fabricmc.fabric.api.event.EventFactory;
@@ -54,7 +53,7 @@ import dev.jpcode.eccore.util.TimeUtil;
 
 import static com.fibermc.essentialcommands.EssentialCommands.CONFIG;
 
-public class PlayerData extends PersistentState implements IServerPlayerEntityData, IFeedbackReceiver {
+public class PlayerData implements IServerPlayerEntityData, IFeedbackReceiver {
 
     // ServerPlayerEntity
     private ServerPlayerEntity player;
@@ -158,7 +157,6 @@ public class PlayerData extends PersistentState implements IServerPlayerEntityDa
         int playerMaxHomes = ECPerms.getHighestNumericPermission(this.player.getCommandSource(), ECPerms.Registry.Group.home_limit_group);
         if (this.homes.size() < playerMaxHomes) {
             homes.putCommand(homeName, minecraftLocation);
-            this.markDirty();
         } else {
             var ecText = ECText.access(this.player);
             var homeNameText = ecText.accent(homeName);
@@ -372,8 +370,8 @@ public class PlayerData extends PersistentState implements IServerPlayerEntityDa
 
     }
 
-    @Override
-    public NbtCompound writeNbt(NbtCompound tag, RegistryWrapper.WrapperLookup wrapperLookup) {
+    private NbtCompound writeNbt(RegistryWrapper.WrapperLookup wrapperLookup) {
+        NbtCompound tag = new NbtCompound();
         tag.put(StorageKey.PLAYER_UUID, Codec.STRING, pUuid.toString());
 
         NbtCompound homesNbt = new NbtCompound();
@@ -395,7 +393,6 @@ public class PlayerData extends PersistentState implements IServerPlayerEntityDa
 
     public void setPreviousLocation(MinecraftLocation location) {
         this.previousLocation = location;
-        this.markDirty();
     }
 
     public MinecraftLocation getPreviousLocation() {
@@ -411,11 +408,7 @@ public class PlayerData extends PersistentState implements IServerPlayerEntityDa
      */
     public boolean removeHome(String homeName) {
         MinecraftLocation old = this.homes.remove(homeName);
-        if (old != null) {
-            this.markDirty();
-            return true;
-        }
-        return false;
+        return old != null;
     }
 
     @Override
@@ -524,14 +517,14 @@ public class PlayerData extends PersistentState implements IServerPlayerEntityDa
 
         reloadFullNickname();
         PlayerDataManager.getInstance().markNicknameDirty(this);
-        this.markDirty();
         // Return codes based on fail/success
         //  ex: caused by profanity filter.
         return resultCode;
     }
 
     public void save(RegistryWrapper.WrapperLookup wrapperLookup) {
-        NbtCompound data = this.writeNbt(new NbtCompound(), wrapperLookup);
+        NbtCompound data = new NbtCompound();
+        data.put("data", this.writeNbt(wrapperLookup));
 
         try {
             NbtIo.writeCompressed(data, this.saveFile.toPath());
@@ -542,7 +535,6 @@ public class PlayerData extends PersistentState implements IServerPlayerEntityDa
 
     public void setTimeUsedRtp(int i) {
         this.timeUsedRtp = i;
-        this.markDirty();
     }
 
     public int getTimeUsedRtp() {

--- a/src/main/java/com/fibermc/essentialcommands/playerdata/PlayerData.java
+++ b/src/main/java/com/fibermc/essentialcommands/playerdata/PlayerData.java
@@ -21,12 +21,12 @@ import com.fibermc.essentialcommands.types.NamedLocationStorage;
 import com.fibermc.essentialcommands.types.NamedMinecraftLocation;
 import com.fibermc.essentialcommands.util.NicknameTextUtil;
 
-import com.mojang.serialization.Codec;
-
 import io.github.ladysnake.pal.Pal;
 import io.github.ladysnake.pal.VanillaAbilities;
 
 import net.minecraft.nbt.NbtOps;
+
+import net.minecraft.util.Uuids;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -327,12 +327,8 @@ public class PlayerData implements IServerPlayerEntityData, IFeedbackReceiver {
 
     public void fromNbt(NbtCompound tag, RegistryWrapper.WrapperLookup wrapperLookup) {
         NbtCompound dataTag = tag.getCompoundOrEmpty("data");
-        Optional<String> uuidOptional = dataTag.get(StorageKey.PLAYER_UUID, Codec.STRING, NbtOps.INSTANCE);
-        if (uuidOptional.isPresent()) {
-            this.pUuid = UUID.fromString(uuidOptional.get());
-        } else {
-            EssentialCommands.LOGGER.warn("PlayerData NBT did not contain a UUID. This is likely a bug.");
-        }
+        dataTag.get(StorageKey.PLAYER_UUID, Uuids.INT_STREAM_CODEC, NbtOps.INSTANCE)
+            .ifPresentOrElse(uuid -> this.pUuid = uuid, () -> EssentialCommands.LOGGER.warn("PlayerData NBT did not contain a UUID. This is likely a bug."));
 
         NamedLocationStorage homes = new NamedLocationStorage();
         NbtElement homesTag = dataTag.get(StorageKey.HOMES);
@@ -372,7 +368,7 @@ public class PlayerData implements IServerPlayerEntityData, IFeedbackReceiver {
 
     private NbtCompound writeNbt(RegistryWrapper.WrapperLookup wrapperLookup) {
         NbtCompound tag = new NbtCompound();
-        tag.put(StorageKey.PLAYER_UUID, Codec.STRING, pUuid.toString());
+        tag.put(StorageKey.PLAYER_UUID, Uuids.INT_STREAM_CODEC, pUuid);
 
         NbtCompound homesNbt = new NbtCompound();
         homes.writeNbt(homesNbt);

--- a/src/main/java/com/fibermc/essentialcommands/playerdata/PlayerDataFactory.java
+++ b/src/main/java/com/fibermc/essentialcommands/playerdata/PlayerDataFactory.java
@@ -43,7 +43,6 @@ public final class PlayerDataFactory {
                 e.printStackTrace();
             }
         } else {
-            pData.markDirty();
             pData.save(DynamicRegistryManager.EMPTY);
         }
 
@@ -80,7 +79,6 @@ public final class PlayerDataFactory {
             }
         }
 
-        pData.markDirty();
         return pData;
     }
 

--- a/src/main/java/com/fibermc/essentialcommands/playerdata/PlayerDataManager.java
+++ b/src/main/java/com/fibermc/essentialcommands/playerdata/PlayerDataManager.java
@@ -269,7 +269,7 @@ public class PlayerDataManager {
                 private boolean hasNoBed() {
                     return (
                         oldPlayerEntity == null ||
-                        oldPlayerEntity.getSpawnPointPosition() == null
+                        oldPlayerEntity.getRespawn() == null
                     );
                 }
 

--- a/src/main/java/com/fibermc/essentialcommands/playerdata/PlayerProfile.java
+++ b/src/main/java/com/fibermc/essentialcommands/playerdata/PlayerProfile.java
@@ -21,15 +21,13 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtElement;
 import net.minecraft.nbt.NbtIo;
-import net.minecraft.registry.RegistryWrapper;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.Style;
-import net.minecraft.world.PersistentState;
 
 import dev.jpcode.eccore.config.ConfigUtil;
 
-public class PlayerProfile extends PersistentState implements IServerPlayerEntityData, IStyleProvider {
+public class PlayerProfile implements IServerPlayerEntityData, IStyleProvider {
 
     private ServerPlayerEntity player;
     private final File saveFile;
@@ -124,8 +122,9 @@ public class PlayerProfile extends PersistentState implements IServerPlayerEntit
             : Optional.empty();
     }
 
-    @Override
-    public NbtCompound writeNbt(NbtCompound tag, RegistryWrapper.WrapperLookup wrapperLookup) {
+    private NbtCompound writeNbt() {
+        NbtCompound tag = new NbtCompound();
+
         this.profileOptions.formattingDefault
             .ifPresent(style -> tag.putString(StorageKey.FORMATTING_DEAULT, ConfigUtil.serializeStyle(style)));
 
@@ -141,8 +140,9 @@ public class PlayerProfile extends PersistentState implements IServerPlayerEntit
         return tag;
     }
 
-    public void save(RegistryWrapper.WrapperLookup wrapperLookup) {
-        NbtCompound data = this.writeNbt(new NbtCompound(), wrapperLookup);
+    public void save() {
+        NbtCompound data = new NbtCompound();
+        data.put("data", this.writeNbt());
 
         try {
             NbtIo.writeCompressed(data, this.saveFile.toPath());

--- a/src/main/java/com/fibermc/essentialcommands/playerdata/PlayerProfileFactory.java
+++ b/src/main/java/com/fibermc/essentialcommands/playerdata/PlayerProfileFactory.java
@@ -2,7 +2,6 @@ package com.fibermc.essentialcommands.playerdata;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Objects;
 
 import com.fibermc.essentialcommands.EssentialCommands;
 import com.fibermc.essentialcommands.util.FileUtil;
@@ -36,8 +35,7 @@ public final class PlayerProfileFactory {
                 e.printStackTrace();
             }
         } else {
-            pData.markDirty();
-            pData.save(Objects.requireNonNull(player.getServer()).getRegistryManager());
+            pData.save();
         }
 
         return pData;

--- a/src/main/java/com/fibermc/essentialcommands/types/MinecraftLocation.java
+++ b/src/main/java/com/fibermc/essentialcommands/types/MinecraftLocation.java
@@ -67,6 +67,9 @@ public class MinecraftLocation {
     }
 
     public static MinecraftLocation fromNbt(NbtCompound tag) {
+        if (tag.isEmpty()) {
+            return null;
+        }
         var loc = new MinecraftLocation();
         loc.loadNbt(tag);
         return loc;

--- a/src/main/java/com/fibermc/essentialcommands/types/WarpLocation.java
+++ b/src/main/java/com/fibermc/essentialcommands/types/WarpLocation.java
@@ -28,14 +28,11 @@ public class WarpLocation extends NamedMinecraftLocation {
     }
 
     public static WarpLocation fromNbt(NbtCompound tag, String name) {
-        String permissionString1 = String.valueOf(tag.getString("permissionString"));
-        if (Objects.equals(permissionString1, "")) {
-            permissionString1 = null;
-        }
+        String permissionString = tag.getString("permissionString", null);
 
         var loc = new WarpLocation();
         loc.loadNbt(tag, name);
-        loc.permissionString = permissionString1;
+        loc.permissionString = permissionString;
         return loc;
     }
 


### PR DESCRIPTION
This PR fixes the EC world data, player data, and player profile data reading/writing. The respective classes no longer extend `PersistentState`, as this class and the functionality it provides wasn't properly used.
In the future it would be good to transition to proper usage of said class, so that all the saved data is stored in the `data` folder in the world save, and codecs are used to read/write data. This would make these classes more future proof and reduce code duplication (the actual saving and reading of the NBT files is handled by Minecraft, for example), but will also require writing code to convert worlds with data in the old folders. This is out of scope for this update.

Along with making these changes, there have also been some other slight changes to fix build errors, and PAL has been bumped to its 1.21.5 version. These changes together make Minecraft successfully run. I've tested some basic features as `/home`, `/warp`, and `/spawn`, however it is good to test other features as well.